### PR TITLE
Add Gamut to supported MCP hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npx -y @paypal/mcp --tools=all PAYPAL_ACCESS_TOKEN="YOUR_ACCESS_TOKEN" PAYPAL_EN
 
 Replace `YOUR_ACCESS_TOKEN` with your PayPal access token. Refer this on how to [generate a PayPal access token](#generating-an-access-token). Alternatively, you could set the PAYPAL_ACCESS_TOKEN in your environment variables.
 
-### Usage with MCP host (Claude Desktop/Cline/Cursor/GitHub Copilot)
+### Usage with MCP host (Claude Desktop/Cline/Cursor/GitHub Copilot/[Gamut](https://www.gamut.so/mcp/payments-finance/paypal))
 
 This guide explains how to integrate the PayPal connector with Claude Desktop.
 


### PR DESCRIPTION
Adds [Gamut](https://www.gamut.so) to the list of supported MCP hosts.

Gamut is an AI agent platform with native MCP support. Users can connect to the PayPal MCP Server directly from the Gamut interface — go to **Connections**, click **Add Connection**, search for **PayPal**, and authenticate via OAuth.